### PR TITLE
Added support for v:count for C-a/C-x

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ require('boole').setup({
   },
   -- User defined loops
   additions = {
-    {'Foo', 'Bar'}
+    {'Foo', 'Bar'},
     {'tic', 'tac', 'toe'}
   },
 })

--- a/lua/boole/init.lua
+++ b/lua/boole/init.lua
@@ -334,9 +334,10 @@ M.run = function(direction)
     if match ~= nil then return vim.cmd(':normal ciw' .. match) end
 
     -- <C-a> and <C-x> compatability
-    if direction == 'increment' then return vim.cmd(':normal!') end
-    if direction == 'decrement' then return vim.cmd(':normal!') end
+    if direction == 'increment' then return vim.cmd(':normal!'..vim.v.count..'') end
+    if direction == 'decrement' then return vim.cmd(':normal!'..vim.v.count..'') end
 
+    vim.api.nvim_cmd()
     return false
 end
 


### PR DESCRIPTION
This is a temporary fix for now, later i would like to add this functionality for all switchable values. 
But for now i felt this was missing.