### PR TITLE
Fix number in word

### DIFF
--- a/lua/boole.lua
+++ b/lua/boole.lua
@@ -357,6 +357,11 @@ function number_exist_in_word(line,current_column)
       if string.match(word_after_cursor,"%d") then
           return true
       end
+  else
+      local last_string = line:sub(current_column+1,string.len(line))
+      if string.match(last_string,"%d") then
+          return true
+      end
   end
   return false
 end

--- a/lua/boole.lua
+++ b/lua/boole.lua
@@ -357,7 +357,8 @@ function number_exist_in_word(line,current_column)
       if string.match(word_after_cursor,"%d") then
           return true
       end
-  else
+  -- no space check it contains number or not
+  elseif space_after_cursor == nil then
       local last_string = line:sub(current_column+1,string.len(line))
       if string.match(last_string,"%d") then
           return true


### PR DESCRIPTION
Sorry that i unauthorized change "normal! l" to "normal! w" before.
This commit comes to fix following bug.
The originl code will check number in word if space after it.
Beacuse I change it to "normal! w" so last word won't be checked in function number_exist_in_word.
This is example _ as cursor 
"test1": _ foo1bar,
"test2": foo2bar,
with < C - a >, won't change foo1_bar pass2,will change test2 to test3
So sorry for that happen if you dislike this way you can change back to "normal! l".