### PR TITLE
Add 'left' and 'right' to boolean toggles

### DIFF
--- a/lua/boole.lua
+++ b/lua/boole.lua
@@ -56,6 +56,7 @@ M.generate({'yes',     'no'},       true)
 M.generate({'on',      'off'},      true)
 M.generate({'enable',  'disable'},  true)
 M.generate({'enabled', 'disabled'}, true)
+M.generate({'left', 'right'}, true)
 
 -- Canonical hours
 M.generate(


### PR DESCRIPTION
Add 'left' and 'right' to boolean toggles

This commit adds the 'left' and 'right' pair to the list of boolean toggles in the `boole.lua` file. This enhancement allows users to easily switch between 'left' and 'right' values using the plugin's toggle functionality.

Changes:
- Added `M.generate({'left', 'right'}, true)` to the list of boolean pairs

This addition expands the utility of the boole.nvim plugin, providing a convenient toggle for directional values that are commonly used in various programming and configuration contexts.